### PR TITLE
Remove creation of `generate-image` directory.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,6 @@ JLink tool allows you to create different scale of JREs. Every application has d
 
 [source,bash]
 ----
-mkdir generate-image
 cd generate-image
 
 // Run


### PR DESCRIPTION
The `generate-image` directory is already available in the repository so `mkdir generate-image` is obsolete. 
It does not make sense either as the `generate-images.*` scripts won't be available in a new folder.